### PR TITLE
Fluid content slider image links (Issue #13404)

### DIFF
--- a/Classes/ViewHelpers/Link/CmsViewHelper.php
+++ b/Classes/ViewHelpers/Link/CmsViewHelper.php
@@ -71,7 +71,11 @@ class Tx_Tev_ViewHelpers_Link_CmsViewHelper extends Tx_Fluid_Core_ViewHelper_Abs
                     ->setCreateAbsoluteUri(true)
                     ->build();
             } else {
-                $formattedLink = 'http://' . $link;
+                $parsedLink = parse_url($link);
+                if (empty($parsedLink['scheme'])) {
+                    $link = 'http://' . ltrim($link, '/');
+                }
+                $formattedLink = $link;
             }
         } else {
             $formattedLink = null;


### PR DESCRIPTION
Links that are created based on config from the 'link' wizard in the CMS were always pre-pending http:// on to them. This meant links with http:// already in were breaking as the scheme was getting doubled up.
- Fix to parse link and only add http:// if scheme is missing.
